### PR TITLE
Make download command's OUT parameter optional, and add mkfw command for combined downloading/decrypting.

### DIFF
--- a/samloader/main.py
+++ b/samloader/main.py
@@ -42,12 +42,14 @@ def checkupdate(model, region):
 @click.argument("version")
 @click.argument("model")
 @click.argument("region")
-@click.argument("out")
+@click.argument("out", nargs = -1)
 def download(version, model, region, out):
     client = fusclient.FUSClient()
     path, filename = getbinaryfile(client, version, region, model)
     initdownload(client, filename)
-    if os.path.isdir(out):
+    if out == ():
+        out = filename
+    elif os.path.isdir(out):
         out = os.path.join(out, filename)
     if os.path.exists(out):
         f = open(out, "ab")


### PR DESCRIPTION
When `OUT` is not given to the **download** command, the filename on the server will be used.

When `OUTFILE` is not given to the **mkfw** command, the filename on the server will be used, minus the `.enc4` or `.enc2` component.