### PR TITLE
If -R is given and there's no file to resume, simply download.

### DIFF
--- a/samloader/main.py
+++ b/samloader/main.py
@@ -34,9 +34,14 @@ def main():
     if args.command == "download":
         client = fusclient.FUSClient()
         path, filename, size = getbinaryfile(client, args.fw_ver, args.dev_model, args.dev_region)
-        print("resuming" if args.resume else "downloading", filename)
         out = args.out_file if args.out_file else os.path.join(args.out_dir, filename)
-        dloffset = os.stat(out).st_size if args.resume else 0
+        try:
+            dloffset = os.stat(out).st_size if args.resume else 0
+        except FileNotFoundError:
+            args.resume = None
+            dloffset = 0
+
+        print("resuming" if args.resume else "downloading", filename)
         if dloffset == size:
             print("already downloaded!")
             return


### PR DESCRIPTION
Switch to downloading when -R is given, but no partial file is found.