### PR TITLE
De-duplicate code in decrypt and download-with-auto-decrypt

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,42 @@
 # samloader
+
 Download firmware for Samsung devices (without any extra Windows drivers).
+
 ## Installation
+
 ```
-pip3 install git+https://github.com/samloader/samloader.git
+$ pip3 install git+https://github.com/samloader/samloader.git
 ```
+
 ## Usage
-Run with `samloader` or `python3 -m samloader`. See `samloader --help` and `samloader (command) --help` for help.
 
-`-m <model> -r <region> checkupdate`: Check the latest firmware version
+Run with `samloader` or `python3 -m samloader`. See `samloader --help` and
+`samloader (command) --help` for help.
 
-`-m <model> -r <region> download -v <version> (-O <output-dir> or -o <output-file>)`: Download the specified firmware version for a given phone and region to a specified file or directory
+Check the latest firmware version: `-m <model> -r <region> checkupdate`
 
-`-m <model> -r <region> decrypt -v <version> -V <enc-version> -i <input-file> -o <output-file>`: Decrypt encrypted firmware
+Download the specified firmware version for a given phone and region to a
+specified file or directory: `-m <model> -r <region> download -v <version> (-O
+<output-dir> or -o <output-file>)`
+
+Decrypt encrypted firmware: `-m <model> -r <region> decrypt -v <version> -V
+<enc-version> -i <input-file> -o <output-file>`
+
 ### Example
+
 ```
 $ samloader -m GT-I8190N -r BTU checkupdate
 I8190NXXAMJ2/I8190NBTUAMJ1/I8190NXXAMJ2/I8190NXXAMJ2
+
 $ samloader -m GT-I8190N -r BTU download -v I8190NXXAMJ2/I8190NBTUAMJ1/I8190NXXAMJ2/I8190NXXAMJ2 -O .
 downloading GT-I8190N_BTU_1_20131118100230_9ae3yzkqmu_fac.zip.enc2
 [################################] 10570/10570 - 00:02:02
+
 $ samloader -m GT-I8190N -r BTU decrypt -v I8190NXXAMJ2/I8190NBTUAMJ1/I8190NXXAMJ2/I8190NXXAMJ2 -V 2 -i GT-I8190N_BTU_1_20131118100230_9ae3yzkqmu_fac.zip.enc2 -o GT-I8190N_BTU_1_20131118100230_9ae3yzkqmu_fac.zip
 [################################] 169115/169115 - 00:00:08
 ```
+
 ## Note
-This project was formerly hosted at `nlscc/samloader`, and has moved to `samloader/samloader`.
+
+This project was formerly hosted at `nlscc/samloader`, and has moved to
+`samloader/samloader`.


### PR DESCRIPTION
High-level file decryption is duplicated in the case of a "decrypt" command and the "download" command with the auto-decrypt option ("-D"). This pull request factors this functionality into a new function "decrypt_file", improving code readability.

A minor typo is also fixed in the print statement (see "decrypting").